### PR TITLE
feat: shopify auto discount add `userError` response response interface

### DIFF
--- a/internal/shopify/discount.go
+++ b/internal/shopify/discount.go
@@ -177,7 +177,8 @@ func (d *discountServiceImpl) Update(
 						shippingDiscounts: %t
 					}
 				}
-			) {
+			) 
+			{
 				automaticAppDiscount {
 					discountId
 					title
@@ -189,6 +190,11 @@ func (d *discountServiceImpl) Update(
 						shippingDiscounts
 					}
 				}
+				userErrors {
+      		field
+      		message
+      		code
+    		}
 			}
 		}
 	`


### PR DESCRIPTION
### 📚 Description

The current [discountAutomaticAppUpdate](https://shopify.dev/docs/api/admin-graphql/unstable/mutations/discountAutomaticAppUpdate) does not define `userError`. Add this interface to facilitate future debugging.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->